### PR TITLE
Fix call to navigator.mediaDevices.getUserMedia()

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -184,9 +184,12 @@ export function endCall() {
 }
 
 function getUserMedia(cb) {
-    navigator.getUserMedia({video: true, audio: true}, (stream) => {
+    navigator.mediaDevices.getUserMedia({video: true, audio: true}).then((stream) => {
         cb(null, stream);
-    }, cb);
+    }).catch((e) => {
+        console.log(`Cannot initialize camera/microphone: ${e}`); //eslint-disable-line
+        cb(e, null);
+    });
 }
 
 function createPeer(stream, initiator, userId, peerId) {


### PR DESCRIPTION
According to MDN, the call `navigator.getUserMedia()` is deprecated. This MR is trying to fix it.

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia